### PR TITLE
depend on mfranke93/wasm-clustering@v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ To build all required files for the frontend (JavaScript, CSS, documentation), t
 $ make prod
 ```
 
+For the web build targets, the `npm` dependencies must have been installed first, see [Installing Dependencies](#Installing-Dependencies).
+For the documentation, a LaTeX distribution including `latexmk` and TikZ must be installed on the system.
+On a Debian or Ubuntu system, these can be installed via the packages `texlive-pictures` and `latexmk`.
+
 
 ### Building the Docker Image
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "ramda": "^0.27.1",
         "tabulator-tables": "^4.8.2",
         "tslib": "^2.3.0",
-        "wasm-clustering": "git+ssh://git@github.com:mfranke93/wasm-clustering.git#v0.1.3"
+        "wasm-clustering": "git+ssh://git@github.com:mfranke93/wasm-clustering.git#v0.2.0"
       },
       "devDependencies": {
         "@babel/plugin-proposal-class-properties": "^7.14.5",
@@ -63,6 +63,12 @@
         "webpack-cli": "^4.3.1",
         "worker-loader": "^3.0.7"
       }
+    },
+    "../wasm-clustering/dist": {
+      "name": "wasm",
+      "version": "0.2.0",
+      "extraneous": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.16.0",
@@ -6566,8 +6572,8 @@
       "dev": true
     },
     "node_modules/wasm-clustering": {
-      "version": "0.1.3",
-      "resolved": "git+ssh://git@github.com/mfranke93/wasm-clustering.git#c250e4aba8364b8f6c1332989839cbd9657b6aa1",
+      "version": "0.2.0",
+      "resolved": "git+ssh://git@github.com/mfranke93/wasm-clustering.git#f08be5a3347c1c0646e9a4a59be8b2b99e055723",
       "license": "MIT"
     },
     "node_modules/watchpack": {
@@ -11979,8 +11985,8 @@
       "dev": true
     },
     "wasm-clustering": {
-      "version": "git+ssh://git@github.com/mfranke93/wasm-clustering.git#c250e4aba8364b8f6c1332989839cbd9657b6aa1",
-      "from": "wasm-clustering@git+ssh://git@github.com:mfranke93/wasm-clustering.git#v0.1.3"
+      "version": "git+ssh://git@github.com/mfranke93/wasm-clustering.git#f08be5a3347c1c0646e9a4a59be8b2b99e055723",
+      "from": "wasm-clustering@git+ssh://git@github.com:mfranke93/wasm-clustering.git#v0.2.0"
     },
     "watchpack": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ramda": "^0.27.1",
     "tabulator-tables": "^4.8.2",
     "tslib": "^2.3.0",
-    "wasm-clustering": "git+ssh://git@github.com:mfranke93/wasm-clustering.git#v0.1.3"
+    "wasm-clustering": "git+ssh://git@github.com:mfranke93/wasm-clustering.git#v0.2.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.14.5",


### PR DESCRIPTION
This removes the need to compile Rust code on the build machine.

re #115