### PR TITLE
Access report by UUID from report root page

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,8 @@
 
 Highlight hovered religion or confidence level in the timeline tooltip. Add
 a way to go to the place URI pages directly from the map. Add history tree
-to visualization (beta testers only).
+to visualization (beta testers only). Add form to navigate to reports by
+UUID.
 
 
 2022-05-12                                            1.1.3+hotfix-wasm-csp

--- a/damast/docs/templates/docs/index.html
+++ b/damast/docs/templates/docs/index.html
@@ -54,7 +54,7 @@
   {%- if 'readdb' in user.roles -%}
   <a class="card" href="{{ url_for('reporting.root') }}">
     <i class="fa fa-4x fa-print fa-fw"></i>
-    <span class="name">Create report from database</span>
+    <span class="name">Create or access report</span>
   </a>
   {%- endif -%}
   {%- if not user.visitor -%}

--- a/damast/reporting/__init__.py
+++ b/damast/reporting/__init__.py
@@ -90,6 +90,19 @@ def create_report():
     return _start_report(filter_json)
 
 
+@app.route('/redirect-to-report-from-uuid', role=['reporting', 'dev', 'admin'], methods=['GET'])
+def report_by_uuid():
+    report_id = flask.request.args.get('uuid', '')
+
+    # check if valid UUID
+    try:
+        u = uuid.UUID(report_id)
+        return flask.redirect(flask.url_for('reporting.get_report', report_id=str(u)))
+
+    except ValueError:
+        raise werkzeug.exceptions.BadRequest('Request must have a uuid parameter that is a valid UUID.')
+
+
 @app.route('/static/<path:path>', role=['reporting', 'dev', 'admin'])
 def file(path):
     return flask.current_app.serve_static_file(static, path)

--- a/damast/reporting/templates/reporting/index.html
+++ b/damast/reporting/templates/reporting/index.html
@@ -8,19 +8,57 @@
 {% endblock %}
 
 {% block content %}
-<h1>Generate a Report</h1>
+<h1>Generate a Textual Report from the Database</h1>
 
-<p>
-  Upload a visualization state file to generate a report.
-  Alternatively, you can generate the report from inside the visualization with its current state by clicking on the <em><q>Generate report</q></em> button in the settings pane.
-</p>
+<section>
+  <p>
+    You can generate a detailed report on the data matching a set of filters from the visualization.
+    These reports are stored permanently, and each one is assigned a <em>universally unique identifier</em> (UUID).
+    The reports can be accessed later if the UUID, or the complete URL, is known, so be sure to save either of those.
+    The URL to a report can also be interpolated from its UUID.
+    For instance, a hypothetical report on this website with the UUID <code>01234567-0123-4567-8901-2345-012345678901</code> would have the URL
+    <code>{{ url_for('reporting.get_report', report_id='01234567-0123-4567-8901-2345-012345678901', _external=True) }}</code>
+  </p>
+</section>
 
-<form action="{{ url_for('reporting.create_report') }}" method="POST" enctype="multipart/form-data">
-  <label for="filter_file">Visualization state file:</label>
-  <input type="file" name="filter_file" accept="application/json" required>
-  <button type="submit" class="button button--medium button--green">
-    <i class="fa fa--pad-right fa-upload"></i>
-    Submit
-  </button>
-</form>
+<section>
+  <h2>Access an Existing Report</h2>
+
+  <p>
+    If you know the UUID to an existing report, you can paste it in the field below, and then click <em><q>Go to report</q></em> to access it directly:
+  </p>
+
+  <form action="{{ url_for('reporting.report_by_uuid') }}" method="GET">
+    <label for="uuid">UUID:</label>
+    <input type="text"
+           name="uuid"
+           placeholder="e.g., 01234567-0123-4567-8901-2345-012345678901"
+           pattern="[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+           size="40"
+           required>
+    <button type="submit" class="button button--medium button--green">
+      <i class="fa fa--pad-right fa-external-link-square"></i>
+      Go to report
+    </button>
+  </form>
+</section>
+
+<section>
+  <h2>Generate a New Report</h2>
+
+  <p>
+    Upload a visualization state file to generate a report.
+    Alternatively, you can generate the report from inside the visualization with its current state by clicking on the <em><q>Generate report</q></em> button in the settings pane.
+  </p>
+
+  <form action="{{ url_for('reporting.create_report') }}" method="POST" enctype="multipart/form-data">
+    <label for="filter_file">Visualization state file:</label>
+    <input type="file" name="filter_file" accept="application/json" required>
+    <button type="submit" class="button button--medium button--green">
+      <i class="fa fa--pad-right fa-upload"></i>
+      Submit
+    </button>
+  </form>
+</section>
 {% endblock %}
+

--- a/src/scss/reporting-form.scss
+++ b/src/scss/reporting-form.scss
@@ -14,14 +14,14 @@ h1 {
   font-size: 2rem;
 }
 
-p,
-form {
-  width: clamp(40ch, 80%, 65ch);
+section {
+  width: clamp(45ch, 80%, 70ch);
   margin-inline: auto;
 }
 
 form {
   max-width: 50ch;
+  margin-inline: auto;
   display: grid;
   gap: 1em;
   grid-template-rows: 1fr 1fr;


### PR DESCRIPTION
The report root page, where one can upload a filter to generate a report, now has a separate form for accessing an existing report by UUID only.

![image](https://user-images.githubusercontent.com/9373678/170015427-347c94fb-76cc-44d0-99eb-cc73bd758a9e.png)

re #155
